### PR TITLE
Update strings to not specify en.lproj

### DIFF
--- a/de/lockwise-ios.xliff
+++ b/de/lockwise-ios.xliff
@@ -1,13 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
-  <file original="CredentialProvider/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="CredentialProvider/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>CredentialProvider</source>
-        <target>CredentialProvider</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName">
@@ -17,39 +16,33 @@
       </trans-unit>
     </body>
   </file>
-  <file original="CredentialProvider/en.lproj/Localizable.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="CredentialProvider/Localizable.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="autofill.enabling">
         <source>Updating AutoFill…</source>
-        <target>AutoFill aktualisieren…</target>
         <note>Text displayed while AutoFill credentials are being populated. AutoFill should be localized to match the proper name for Apple’s system feature</note>
       </trans-unit>
       <trans-unit id="autofill.finished_enabling">
         <source>Finished updating AutoFill</source>
-        <target>Das Aktualisieren von AutoFill ist abgeschlossen</target>
         <note>Accessibility notification when AutoFill is done being enabled</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequired">
         <source>Sign in Required</source>
-        <target>Anmeldung erforderlich</target>
         <note>Title for alert dialog explaining that a user must be signed in to use AutoFill.</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequiredBody">
         <source>You must be signed in to %@ before AutoFill will allow access to passwords within it.</source>
-        <target>Sie müssen bei %@ angemeldet sein, bevor AutoFill Zugriff auf die darin enthaltenen Kennwörter zulässt.</target>
         <note>Body for alert dialog explaining that a user must be signed in to use AutoFill. AutoFill should be localized to match the proper name for Apple's system feature. %1$@ and %2$@ will be replaced with the application name</note>
       </trans-unit>
       <trans-unit id="cancel">
         <source>Cancel</source>
-        <target>Abbrechen</target>
         <note>Cancel button title</note>
       </trans-unit>
       <trans-unit id="firefoxLockbox">
         <source>Firefox Lockwise</source>
-        <target>Firefox Lockwise</target>
         <note>Product Name</note>
       </trans-unit>
       <trans-unit id="list.empty">
@@ -98,7 +91,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -118,7 +111,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/Strings/en.lproj/Localizable.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/Localizable.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -149,7 +142,6 @@
       </trans-unit>
       <trans-unit id="autofill.signInRequired">
         <source>Sign in Required</source>
-        <target>Anmeldung im Common erforderlich</target>
         <note>Title for alert dialog explaining that a user must be signed in to use AutoFill.</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequiredBody">
@@ -162,7 +154,6 @@
       </trans-unit>
       <trans-unit id="cancel">
         <source>Cancel</source>
-        <target>Abbrechen</target>
         <note>Cancel button title</note>
       </trans-unit>
       <trans-unit id="close">
@@ -251,7 +242,7 @@
       </trans-unit>
       <trans-unit id="password_accessibility_instructions">
         <source>Password: double tap to copy %@</source>
-        <note>Accessibility label and instructions for password section of login details</note>
+        <note>Accessibility label and instructions for password section of login details. %@ will be replaced with the password value</note>
       </trans-unit>
       <trans-unit id="reauth_required">
         <source>Reauthentication Required</source>
@@ -451,7 +442,7 @@
       </trans-unit>
       <trans-unit id="username_accessibility_instructions">
         <source>Username: double tap to copy %@</source>
-        <note>Accessibility label and instructions for username section of login details</note>
+        <note>Accessibility label and instructions for username section of login details. %@ will be replaced with the username value</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -644,8 +635,8 @@
         <note>Class = "UILabel"; text = "Take your passwords everywhere"; ObjectID = "hwO-wS-oS4"; Note = "This is the sentence consistently used across marketing and other applications";</note>
       </trans-unit>
       <trans-unit id="xyY-bk-Xw8.text">
-        <source>To use Lockwise, you’ll need a Firefox Account with saved logins.</source>
-        <note>Class = "UILabel"; text = "To use Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account should be consistently translated to match the product name";</note>
+        <source>To use Firefox Lockwise, you’ll need a Firefox Account with saved logins.</source>
+        <note>Class = "UILabel"; text = "To use Firefox Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account and Lockwise should be consistently translated to match the product names";</note>
       </trans-unit>
     </body>
   </file>

--- a/de/lockwise-ios.xliff
+++ b/de/lockwise-ios.xliff
@@ -7,6 +7,7 @@
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>CredentialProvider</source>
+	<target>CredentialProvider</target>
         <note>Bundle display name</note>
       </trans-unit>
       <trans-unit id="CFBundleName">
@@ -23,26 +24,32 @@
     <body>
       <trans-unit id="autofill.enabling">
         <source>Updating AutoFill…</source>
+	<target>AutoFill aktualisieren…</target>
         <note>Text displayed while AutoFill credentials are being populated. AutoFill should be localized to match the proper name for Apple’s system feature</note>
       </trans-unit>
       <trans-unit id="autofill.finished_enabling">
         <source>Finished updating AutoFill</source>
+	<target>Das Aktualisieren von AutoFill ist abgeschlossen</target>
         <note>Accessibility notification when AutoFill is done being enabled</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequired">
         <source>Sign in Required</source>
+	<target>Anmeldung erforderlich</target>
         <note>Title for alert dialog explaining that a user must be signed in to use AutoFill.</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequiredBody">
         <source>You must be signed in to %@ before AutoFill will allow access to passwords within it.</source>
+	<target>Sie müssen bei %@ angemeldet sein, bevor AutoFill Zugriff auf die darin enthaltenen Kennwörter zulässt.</target>
         <note>Body for alert dialog explaining that a user must be signed in to use AutoFill. AutoFill should be localized to match the proper name for Apple's system feature. %1$@ and %2$@ will be replaced with the application name</note>
       </trans-unit>
       <trans-unit id="cancel">
         <source>Cancel</source>
+	<target>Abbrechen</target>
         <note>Cancel button title</note>
       </trans-unit>
       <trans-unit id="firefoxLockbox">
         <source>Firefox Lockwise</source>
+	<target>Firefox Lockwise</target>
         <note>Product Name</note>
       </trans-unit>
       <trans-unit id="list.empty">
@@ -142,6 +149,7 @@
       </trans-unit>
       <trans-unit id="autofill.signInRequired">
         <source>Sign in Required</source>
+	<target>Anmeldung im Common erforderlich</target>
         <note>Title for alert dialog explaining that a user must be signed in to use AutoFill.</note>
       </trans-unit>
       <trans-unit id="autofill.signInRequiredBody">
@@ -154,6 +162,7 @@
       </trans-unit>
       <trans-unit id="cancel">
         <source>Cancel</source>
+	<target>Abbrechen</target>
         <note>Cancel button title</note>
       </trans-unit>
       <trans-unit id="close">

--- a/en-US/lockwise-ios.xliff
+++ b/en-US/lockwise-ios.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
-  <file original="CredentialProvider/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="CredentialProvider/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -17,7 +17,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="CredentialProvider/en.lproj/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="CredentialProvider/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -106,7 +106,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -128,7 +128,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/Strings/en.lproj/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/Localizable.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -291,7 +291,7 @@
       <trans-unit id="password_accessibility_instructions">
         <source>Password: double tap to copy %@</source>
         <target>Password: double tap to copy %@</target>
-        <note>Accessibility label and instructions for password section of login details</note>
+        <note>Accessibility label and instructions for password section of login details. %@ will be replaced with the password value</note>
       </trans-unit>
       <trans-unit id="reauth_required">
         <source>Reauthentication Required</source>
@@ -541,7 +541,7 @@
       <trans-unit id="username_accessibility_instructions">
         <source>Username: double tap to copy %@</source>
         <target>Username: double tap to copy %@</target>
-        <note>Accessibility label and instructions for username section of login details</note>
+        <note>Accessibility label and instructions for username section of login details. %@ will be replaced with the username value</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -768,9 +768,9 @@
         <note>Class = "UILabel"; text = "Take your passwords everywhere"; ObjectID = "hwO-wS-oS4"; Note = "This is the sentence consistently used across marketing and other applications";</note>
       </trans-unit>
       <trans-unit id="xyY-bk-Xw8.text">
-        <source>To use Lockwise, you’ll need a Firefox Account with saved logins.</source>
-        <target>To use Lockwise, you’ll need a Firefox Account with saved logins.</target>
-        <note>Class = "UILabel"; text = "To use Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account should be consistently translated to match the product name";</note>
+        <source>To use Firefox Lockwise, you’ll need a Firefox Account with saved logins.</source>
+        <target>To use Firefox Lockwise, you’ll need a Firefox Account with saved logins.</target>
+        <note>Class = "UILabel"; text = "To use Firefox Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account and Lockwise should be consistently translated to match the product names";</note>
       </trans-unit>
     </body>
   </file>

--- a/templates/lockwise-ios.xliff
+++ b/templates/lockwise-ios.xliff
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
-  <file original="CredentialProvider/en.lproj/InfoPlist.strings" source-language="en" datatype="plaintext">
+  <file original="CredentialProvider/InfoPlist.strings" source-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -15,7 +15,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="CredentialProvider/en.lproj/Localizable.strings" source-language="en" datatype="plaintext">
+  <file original="CredentialProvider/Localizable.strings" source-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -89,7 +89,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/en.lproj/InfoPlist.strings" source-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -108,7 +108,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/Strings/en.lproj/Localizable.strings" source-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/Localizable.strings" source-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -239,7 +239,7 @@
       </trans-unit>
       <trans-unit id="password_accessibility_instructions">
         <source>Password: double tap to copy %@</source>
-        <note>Accessibility label and instructions for password section of login details</note>
+        <note>Accessibility label and instructions for password section of login details. %@ will be replaced with the password value</note>
       </trans-unit>
       <trans-unit id="reauth_required">
         <source>Reauthentication Required</source>
@@ -439,7 +439,7 @@
       </trans-unit>
       <trans-unit id="username_accessibility_instructions">
         <source>Username: double tap to copy %@</source>
-        <note>Accessibility label and instructions for username section of login details</note>
+        <note>Accessibility label and instructions for username section of login details. %@ will be replaced with the username value</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -631,8 +631,8 @@
         <note>Class = "UILabel"; text = "Take your passwords everywhere"; ObjectID = "hwO-wS-oS4"; Note = "This is the sentence consistently used across marketing and other applications";</note>
       </trans-unit>
       <trans-unit id="xyY-bk-Xw8.text">
-        <source>To use Lockwise, you’ll need a Firefox Account with saved logins.</source>
-        <note>Class = "UILabel"; text = "To use Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account should be consistently translated to match the product name";</note>
+        <source>To use Firefox Lockwise, you’ll need a Firefox Account with saved logins.</source>
+        <note>Class = "UILabel"; text = "To use Firefox Lockwise, you’ll need a Firefox Account with saved logins."; ObjectID = "xyY-bk-Xw8"; Note = "These are instructions that to use the application, a Firefox Account is need. Firefox Account and Lockwise should be consistently translated to match the product names";</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
The export script was including `en.lproj` in the path. That was causing an incorrect path for import.