### PR TITLE
20190622 1117

### DIFF
--- a/de/lockwise-ios.xliff
+++ b/de/lockwise-ios.xliff
@@ -77,10 +77,14 @@
         <target>Anmelden</target>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Dies entsperrt die App.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -94,6 +98,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <target>Nehmen Sie Ihre Passwörter überall mit hin</target>
@@ -101,15 +109,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>Lockwise</source>
-        <target>Lockwise</target>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <target>Firefox Lockbox</target>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -298,6 +314,10 @@
         <target>Zugangsdaten durchsuchen</target>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <target>Passcode festlegen</target>
@@ -483,6 +503,10 @@
         <target>Optionen zum Sortieren der Liste Ihrer Zugangsdaten auswählen (derzeit %@)</target>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <target>Zugangsdaten synchronisieren…</target>
@@ -496,7 +520,7 @@
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Dies entsperrt die App.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -714,6 +738,10 @@
         <source>Select Lockwise</source>
         <target>Lockwise auswählen</target>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>

--- a/en-US/lockwise-ios.xliff
+++ b/en-US/lockwise-ios.xliff
@@ -77,10 +77,15 @@
         <target>Sign In</target>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <target>Sync timed out</target>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>This will unlock the app.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -94,6 +99,11 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <target>Firefox Lockwise</target>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <target>Take your passwords everywhere</target>
@@ -101,7 +111,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -110,6 +120,16 @@
         <source>Lockwise</source>
         <target>Lockwise</target>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <target>Firefox Lockbox</target>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <target>Firefox Lockwise will use Face ID to sign you in to the app.</target>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -298,6 +318,11 @@
         <target>Search logins</target>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <target>Sync between devices with secure 256-bit encryption</target>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <target>Set Passcode</target>
@@ -483,6 +508,11 @@
         <target>Select options for sorting your list of logins (currently %@)</target>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <target>Sync timed out</target>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <target>Syncing your logins</target>
@@ -496,7 +526,7 @@
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>This will unlock the app.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -714,6 +744,11 @@
         <source>Select Lockwise</source>
         <target>Select Lockwise</target>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <target>Deselect iCloud Keychain</target>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>

--- a/es/lockwise-ios.xliff
+++ b/es/lockwise-ios.xliff
@@ -77,10 +77,14 @@
         <target>Iniciar sesión</target>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Se desbloqueará la aplicación.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -94,6 +98,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <target>Lleva tus contraseñas a todos lados</target>
@@ -101,15 +109,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="es" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" target-language="es" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>Lockwise</source>
-        <target>Lockwise</target>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <target>Firefox Lockbox</target>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -298,6 +314,10 @@
         <target>Buscar usuarios</target>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <target>Establecer código de acceso</target>
@@ -483,6 +503,10 @@
         <target>Selecciona las opciones para ordenar la lista de usuarios (actualmente %@)</target>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <target>Sincronizar usuarios</target>
@@ -496,7 +520,7 @@
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Se desbloqueará la aplicación.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -714,6 +738,10 @@
         <source>Select Lockwise</source>
         <target>Seleccionar Lockwise</target>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>

--- a/fr/lockwise-ios.xliff
+++ b/fr/lockwise-ios.xliff
@@ -77,10 +77,14 @@
         <target>Connexion</target>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Ceci va déverrouiller l’application.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -94,6 +98,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <target>Emportez vos mots de passe partout.</target>
@@ -101,15 +109,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>Lockwise</source>
-        <target>Lockwise</target>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <target>Firefox Lockbox</target>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -298,6 +314,10 @@
         <target>Rechercher des identifiants</target>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <target>Définir un code d’accès</target>
@@ -483,6 +503,10 @@
         <target>Sélectionnez des options pour trier votre liste d’identifiants (actuellement %@)</target>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <target>Synchronisation de vos identifiants</target>
@@ -496,7 +520,7 @@
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Ceci va déverrouiller l’application.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -714,6 +738,10 @@
         <source>Select Lockwise</source>
         <target>Sélectionnez Lockwise</target>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>

--- a/it/lockwise-ios.xliff
+++ b/it/lockwise-ios.xliff
@@ -77,10 +77,14 @@
         <target>Accedi</target>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Questa operazione sbloccherà l’app.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -94,6 +98,10 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <target>Porta le tue password sempre con te</target>
@@ -101,15 +109,23 @@
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" target-language="it" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" target-language="it" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
       <trans-unit id="CFBundleDisplayName">
         <source>Lockwise</source>
-        <target>Lockwise</target>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <target>Firefox Lockbox</target>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -298,6 +314,10 @@
         <target>Cerca nelle credenziali</target>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <target>Imposta codice</target>
@@ -483,6 +503,10 @@
         <target>Seleziona in che ordine visualizzare le credenziali (attualmente “%@”)</target>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <target>Sincronizzazione delle credenziali</target>
@@ -496,7 +520,7 @@
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
         <target>Questa operazione sbloccherà l’app.</target>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -714,6 +738,10 @@
         <source>Select Lockwise</source>
         <target>Seleziona Lockwise</target>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>

--- a/templates/lockwise-ios.xliff
+++ b/templates/lockwise-ios.xliff
@@ -64,9 +64,13 @@
         <source>Sign In</source>
         <note>Sign in button text</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="username_placeholder">
         <source>(no username)</source>
@@ -79,13 +83,17 @@
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
     <body>
+      <trans-unit id="ehm-2v-Rbb.accessibilityLabel">
+        <source>Firefox Lockwise</source>
+        <note>Class = "UIImageView"; accessibilityLabel = "Firefox Lockwise"; ObjectID = "ehm-2v-Rbb"; Note = "Text logo of the product name for screenreaders";</note>
+      </trans-unit>
       <trans-unit id="hwO-wS-oS4.text">
         <source>Take your passwords everywhere</source>
         <note>Class = "UILabel"; text = "Take your passwords everywhere"; ObjectID = "hwO-wS-oS4";</note>
       </trans-unit>
     </body>
   </file>
-  <file original="lockbox-ios/Common/Resources/InfoPlist.strings" source-language="en" datatype="plaintext">
+  <file original="lockbox-ios/Common/Resources/Strings/InfoPlist.strings" source-language="en" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="10.2.1" build-num="10E1001"/>
     </header>
@@ -93,6 +101,14 @@
       <trans-unit id="CFBundleDisplayName">
         <source>Lockwise</source>
         <note>Bundle display name</note>
+      </trans-unit>
+      <trans-unit id="CFBundleName">
+        <source>Firefox Lockbox</source>
+        <note>Bundle name</note>
+      </trans-unit>
+      <trans-unit id="NSFaceIDUsageDescription">
+        <source>Firefox Lockwise will use Face ID to sign you in to the app.</source>
+        <note>Privacy - Face ID Usage Description</note>
       </trans-unit>
     </body>
   </file>
@@ -245,6 +261,10 @@
         <source>Search logins</source>
         <note>Placeholder text for search field</note>
       </trans-unit>
+      <trans-unit id="securityTheather.syncBetweenDevices">
+        <source>Sync between devices with secure 256-bit encryption</source>
+        <note>Text shown on security screen during onboarding.</note>
+      </trans-unit>
       <trans-unit id="set_passcode">
         <source>Set Passcode</source>
         <note>Label for button allowing users to go to passcode settings</note>
@@ -393,6 +413,10 @@
         <source>Select options for sorting your list of logins (currently %@)</source>
         <note>Accessibility identifier for the sorting options button. %@ will be replaced with the currently-set sort option</note>
       </trans-unit>
+      <trans-unit id="sync.timeout">
+        <source>Sync timed out</source>
+        <note>This is the message displayed when syncing entries from the server times out</note>
+      </trans-unit>
       <trans-unit id="syncing_entries">
         <source>Syncing your logins</source>
         <note>Label and accessibility callout for Syncing your logins spinner and HUD</note>
@@ -403,7 +427,7 @@
       </trans-unit>
       <trans-unit id="unlock_placeholder">
         <source>This will unlock the app.</source>
-        <note>Placeholder text when the user’s email is unavailable while unlocking Lockwise, shown in Touch ID and passcode prompts</note>
+        <note>Placeholder text when the user’s email is unavailable while unlocking the app, shown in Touch ID and passcode prompts</note>
       </trans-unit>
       <trans-unit id="unlock_with_faceid">
         <source>Unlock with Face ID</source>
@@ -586,6 +610,10 @@
       <trans-unit id="r0I-o4-2Ym.text">
         <source>Select Lockwise</source>
         <note>Class = "UILabel"; text = "Select Lockwise"; ObjectID = "r0I-o4-2Ym"; Note = "The instruction to tap the name of this application. Lockwise should not be translated";</note>
+      </trans-unit>
+      <trans-unit id="vcZ-pI-Mgz.text">
+        <source>Deselect iCloud Keychain</source>
+        <note>Class = "UILabel"; text = "Deselect iCloud Keychain"; ObjectID = "vcZ-pI-Mgz"; Note = "The instruction to unselect a default setting. iCloud Keychain should match the system setting item name";</note>
       </trans-unit>
       <trans-unit id="xig-s8-dim.text">
         <source>Open the Settings app</source>


### PR DESCRIPTION
This supersedes https://github.com/mozilla-l10n/lockwiseios-l10n/pull/5 and includes a few new strings as part of the 1.6.x series of development and app improvements.

@Pike based on this diff to the `ios-l10n-scripts` export script...

```diff
diff --git a/export-locales.sh b/export-locales.sh
index 880e0ae..fe73562 100755
--- a/export-locales.sh
+++ b/export-locales.sh
@@ -95,7 +95,7 @@ fi
 /usr/bin/perl -p -i -e "s|OpenInFocus/en.lproj/InfoPlist.strings|OpenInFocus/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|CredentialProvider/en.lproj/InfoPlist.strings|CredentialProvider/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|CredentialProvider/en.lproj/Localizable.strings|CredentialProvider/Localizable.strings|g" /tmp/en.xliff
-/usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/en.lproj/InfoPlist.strings|lockbox-ios/Common/Resources/InfoPlist.strings|g" /tmp/en.xliff
+/usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/Strings/en.lproj/InfoPlist.strings|lockbox-ios/Common/Resources/Strings/InfoPlist.strings|g" /tmp/en.xliff
 /usr/bin/perl -p -i -e "s|lockbox-ios/Common/Resources/Strings/en.lproj/Localizable.strings|lockbox-ios/Common/Resources/Strings/Localizable.strings|g" /tmp/en.xliff
```

.. I think this resulting PR is looking much better with less "surprises" around file paths (just the adding to the "Strings" directory). How's it look to you all?